### PR TITLE
fix gorm sql parameter not auto clean

### DIFF
--- a/mysql/mysql_table.go
+++ b/mysql/mysql_table.go
@@ -22,7 +22,6 @@ func newMysqlTable(db *gorm.DB) *MysqlTable {
 func (mt *MysqlTable) registerModel(model UserDefinedModel) error {
 	mt.tableName = model.TableName()
 	mt.tableModel = model
-	mt.DB = mt.DB.Table(model.TableName())
 	return nil
 }
 


### PR DESCRIPTION
FIXBUG #13 
Delete `db := db.Table(model.TableName())`
Exposition:
Although the return value of the `db.Table(model.TableName())` is of type `*gorm.DB`, it is different from `db`.
In fact, this return value is called `tx` in Gorm source code. `tx` will continuously accumulate SQL parameters instead of being cleared after execution.
For example, when you first query `id = 1` and then want to query `id = 2`, the program using `tx` will execute `id = 1 AND id = 2`.